### PR TITLE
Added pass-through to delegate of controller:didChangeSection:atIndex:forChangeType:

### DIFF
--- a/TAFetchedResultsController/TAFetchedResultsController.m
+++ b/TAFetchedResultsController/TAFetchedResultsController.m
@@ -432,6 +432,20 @@
     }
 
     [self updateSections];
+
+    if ([_delegate respondsToSelector:@selector(controller:didChangeSection:atIndex:forChangeType:)]) {
+        NSIndexPath *convertedIndexPath = [NSIndexPath indexPathForRow:0 inSection:(NSInteger)sectionIndex];
+        if (type != NSFetchedResultsChangeInsert) {
+            // The indexPath must exist - convert it...
+            convertedIndexPath = [self convertNSFetchedResultsSectionIndexToUITableViewControllerSectionIndex:convertedIndexPath usingMapping:self.previousMapping];
+            NSLog(@"Converted sectionIndex from %ld to %ld", (long)sectionIndex, (long)convertedIndexPath.section);
+        }
+
+        [_delegate controller:self
+             didChangeSection:self.previousMapping[(NSUInteger)convertedIndexPath.section]
+                      atIndex:(NSUInteger)convertedIndexPath.section
+                forChangeType:type];
+    }
 }
 
 - (void)controller:(NSFetchedResultsController *)controller


### PR DESCRIPTION
Without this change, if you have sections with rows in them, and delete the section (with a cascade delete in the data model), then the section gets deleted in the model, but since the delegate's controller:didChangeSection:atIndex:forChangeType: isn't being called (although controller:didChangeObject:atIndexPath:forChangeType:newIndexPath: is called), nothing is ever calling deleteSections:withRowAnimation: and so an exception gets thrown during controllerDidChangeContent:, and the table isn't properly updated.
