### PR TITLE
Add ability to use keypath of the managed object as section grouping

### DIFF
--- a/TAFetchedResultsController/TAFetchedResultsController.m
+++ b/TAFetchedResultsController/TAFetchedResultsController.m
@@ -138,8 +138,11 @@
 
         // The last part of the key path is the property in the section Entity that's used for the sort order.
         
-        NSArray *keyNameParts = [sectionGroupingKeyPath componentsSeparatedByString:@"."];
-        self.propertyNameForSectionGrouping = [keyNameParts objectAtIndex:keyNameParts.count - 1];
+        NSRange keyPathRange = [sectionGroupingKeyPath rangeOfString: @"."];
+        if (keyPathRange.location != NSNotFound)
+        {
+            self.propertyNameForSectionGrouping = [sectionGroupingKeyPath substringFromIndex: keyPathRange.location + 1];
+        }
         
         _sectionFetchRequest = sectionFetchRequest;
         _managedObjectContext = context;


### PR DESCRIPTION
Currently, the section grouping keypath must reference a value on the section managed object. This change allows the section grouping keypath to be a keypath on the section managed object.

## Example
Currently, using the sectionGroupingKeyPath `section.uuid` is valid because `uuid` is a value on the section managed object.
```
TAFetchedResultsController *taFetchedResultsController = [[TAFetchedResultsController alloc] initWithItemFetchRequest:itemFetchRequest
    sectionFetchRequest:sectionFetchRequest
    managedObjectContext:self.managedObjectContext
    sectionGroupingKeyPath:@"section.uuid"
    cacheName:nil];
```

However, if `section.uuid` was `section.subsection.uuid` an error would be thrown because we would attempt to find the value `uuid` on the section managed object. Instead, we now look for the keypath `subsection.uuid` on the section managed object.
```
TAFetchedResultsController *taFetchedResultsController = [[TAFetchedResultsController alloc] initWithItemFetchRequest:itemFetchRequest
    sectionFetchRequest:sectionFetchRequest
    managedObjectContext:self.managedObjectContext
    sectionGroupingKeyPath:@"section.uuid"
    cacheName:nil];
```